### PR TITLE
use no subdomain path for localhost

### DIFF
--- a/lib/rack/subdomain.rb
+++ b/lib/rack/subdomain.rb
@@ -47,7 +47,7 @@ module Rack
   private
 
     def subdomain
-      @env['HTTP_HOST'].sub(/\.?#{@domain}.*$/,'')
+      @env['HTTP_HOST'].sub(/\.?#{@domain}.*$/,'') unless @env['HTTP_HOST'].match(/^localhost/)
     end
 
     def remap_with_substituted_path!(path)


### PR DESCRIPTION
When HTTP_HOST begins with localhost, act as if the user had used the naked domain or www subdomain.

Fixes #2.
