### PR TITLE
No subdomain for ip addresses

### DIFF
--- a/lib/rack/subdomain.rb
+++ b/lib/rack/subdomain.rb
@@ -60,7 +60,7 @@ module Rack
   private
 
     def subdomain
-      @env['HTTP_HOST'].sub(/\.?#{domain}.*$/,'') unless @env['HTTP_HOST'].match(/^localhost/)
+      @env['HTTP_HOST'].sub(/\.?#{domain}.*$/,'') unless @env['HTTP_HOST'].match(/^localhost/) || @env['SERVER_NAME'] =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
     end
 
     def remap_with_substituted_path!(path)


### PR DESCRIPTION
don't set a subdomain when using an ip address.  127.0.0.1 would set it to 127.0
