### PR TITLE
Support HTTP/1.0 requests. Attempts to fix https://github.com/mattt/rack-subdomain/issues/8

### DIFF
--- a/lib/rack/subdomain.rb
+++ b/lib/rack/subdomain.rb
@@ -61,6 +61,10 @@ module Rack
     end
 
     def subdomain
+      # Support HTTP/1.0 clients, because OpenShift's scalable app
+      # monitoring service uses HTTP/1.0.
+      return nil if @env['HTTP_HOST'].nil?
+
       @env['HTTP_HOST'].sub(/\.?#{domain}.*$/,'') unless @env['HTTP_HOST'].match(/^localhost/) or IPAddress.valid?(@env['SERVER_NAME'])
     end
 


### PR DESCRIPTION
HTTP/1.0 requests might not specify HTTP_HOST (the "Host" header). We now "give up" on trying to compute the subdomain for these requests, since we can't figure it out. At least that's the intent
of answering nil as "the subdomain" of the request.

I would prefer to make this intent clearer, and intend to do that at some point. I'm afraid of other unintended consequences of `subdomain()` answering `nil`. Comments very welcome to help me reverse-engineer the underlying function contracts.
